### PR TITLE
Documentation: Linux pre installation steps; include the install of p…

### DIFF
--- a/introduction/installation-options/install-linux.md
+++ b/introduction/installation-options/install-linux.md
@@ -29,7 +29,7 @@ apt install apache2 php mysql-server php-gd php-mysql php-zip php-curl php-gette
 For PHP 8, this may look a bit different:
 
 ``` sh 
-apt install php8.0-mysql php8.0-gd php8.0-zip php8.0-curl php8.0-gettext php8.0-pdo php8.0-xml php8.0-mbstring
+apt install php8.0-mysql php8.0-gd php8.0-zip php8.0-curl php8.0-gettext php8.0-pdo php8.0-xml php8.0-mbstring php8.0-intl
 ```
 
 The relevant packages will be installed, however, you still need to enable mod_rewrite on Apache.


### PR DESCRIPTION
…hp8.0-intl

Update the new Gibbon documentation: Linux pre installation steps; include the install of php8.0-intl since it is a requirement

<!--- Please provide a general summary of your changes. If you've created a new page or made signifigant changes to the content feel free to add your GitHub username to the contributors list at the top of the changed file. -->
Update on the new Gibbon documentation for Linux pre installation steps; this is a small change on the install process to include the install of php8.0-intl which is a requirement.