### PR TITLE
Docker set up for deploying local vitepress server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .vitepress/.temp
+node_modules/
+.env

--- a/ops/Dockerfile
+++ b/ops/Dockerfile
@@ -1,0 +1,15 @@
+ARG NODE_VERSION
+FROM node:${NODE_VERSION}-alpine
+
+# Install git and other dependencies
+RUN apk add --no-cache git
+
+# Set working directory
+WORKDIR /app
+
+# Expose the default VitePress port
+EXPOSE 5173
+
+# Run VitePress dev server
+# Source files and node_modules are mounted via docker-compose volumes
+CMD ["npm", "run", "docs:dev", "--", "--host", "0.0.0.0"]

--- a/ops/Dockerfile
+++ b/ops/Dockerfile
@@ -1,13 +1,19 @@
 ARG NODE_VERSION
 FROM node:${NODE_VERSION}-alpine
 
-# Install git and other dependencies
-RUN apk add --no-cache git
+ARG NODE_ENV
+ENV NODE_ENV ${NODE_ENV}
 
 # Set working directory
-WORKDIR /app
+WORKDIR /usr/src/app
 
-# Expose the default VitePress port
+# Install git
+RUN apk add --no-cache git
+
+# Swtich to non-root user
+USER node
+
+# Expose default VitePress port
 EXPOSE 5173
 
 # Run VitePress dev server

--- a/ops/Dockerfile
+++ b/ops/Dockerfile
@@ -11,5 +11,4 @@ WORKDIR /app
 EXPOSE 5173
 
 # Run VitePress dev server
-# Source files and node_modules are mounted via docker-compose volumes
 CMD ["npm", "run", "docs:dev", "--", "--host", "0.0.0.0"]

--- a/ops/README.md
+++ b/ops/README.md
@@ -1,6 +1,6 @@
 # Docker Setup for Gibbon Documentation
 
-This Docker setup allows developers to run VitePress without needing Node.js and npm installed locally.
+This Docker setup allows developers to run a local VitePress server for viewing Gibbon documentation without needing Node.js and npm to be installed locally.
 
 ## Prerequisites
 
@@ -8,16 +8,16 @@ Install Docker Desktop from [docker.com](https://www.docker.com/products/docker-
 
 ## Usage
 
-From the project root:
+From the project root, execute the following command to start the VitePress server:
 
 ```bash
 ./up.sh
 ```
 
 This script will:
-- ✅ Check if Docker is running
-- ✅ Verify `docker-compose.yml` exists
-- ✅ Build and start the Vitepress server container
+* Check if Docker Desktop is running.
+* Check `.env` file exists and create it if not.
+* Build and start the Vitepress server container
 
 The documentation will be available at **http://localhost:5173**
 

--- a/ops/README.md
+++ b/ops/README.md
@@ -1,0 +1,27 @@
+# Docker Setup for Gibbon Documentation
+
+This Docker setup allows developers to run VitePress without needing Node.js and npm installed locally.
+
+## Prerequisites
+
+Install Docker Desktop from [docker.com](https://www.docker.com/products/docker-desktop)
+
+## Usage
+
+From the project root:
+
+```bash
+./up.sh
+```
+
+This script will:
+- ✅ Check if Docker is running
+- ✅ Verify `docker-compose.yml` exists
+- ✅ Build and start the Vitepress server container
+
+The documentation will be available at **http://localhost:5173**
+
+To stop the server:
+```bash
+docker-compose down
+```

--- a/ops/compose.yaml
+++ b/ops/compose.yaml
@@ -10,8 +10,8 @@ services:
     ports:
       - "5173:5173"
     volumes:
-      - ${APPLICATION}:/app
-      - ${APPLICATION}/node_modules:/app/node_modules
+      - ${APPLICATION}:/usr/src/app
+      - ${APPLICATION}/node_modules:/usr/src/app/node_modules
     environment:
       - VITE_APP_TITLE=Gibbon Docs
       - NODE_ENV=development

--- a/ops/docker-compose.yml
+++ b/ops/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.8'
+
+services:
+  vitepress:
+    build:
+      context: ..
+      dockerfile: ops/Dockerfile
+      args:
+        - NODE_VERSION=${NODE_VERSION}
+    ports:
+      - "5173:5173"
+    volumes:
+      - ..:/app
+      - ../node_modules:/app/node_modules
+    environment:
+      - VITE_APP_TITLE=Gibbon Docs
+      - NODE_ENV=development

--- a/ops/docker-compose.yml
+++ b/ops/docker-compose.yml
@@ -10,8 +10,8 @@ services:
     ports:
       - "5173:5173"
     volumes:
-      - ..:/app
-      - ../node_modules:/app/node_modules
+      - ${APPLICATION}:/app
+      - ${APPLICATION}/node_modules:/app/node_modules
     environment:
       - VITE_APP_TITLE=Gibbon Docs
       - NODE_ENV=development

--- a/ops/env-sample
+++ b/ops/env-sample
@@ -1,17 +1,15 @@
-###########################################################
+################################################################################
 # General Setup
-###########################################################
+################################################################################
 
-### Compose files  ###############################################################################################
-# The file paths where docker-compose can file its YAML file
-
+# Compose files
 COMPOSE_FILE=ops/docker-compose.yml
 
-### prefix for local container ##############################################################################
+# Prefix for local container
 COMPOSE_PROJECT_NAME=gibbondocs
 
-### Application
+# Application
 APPLICATION=..
 
-### Core services managed in Docker compose ##############################################################################
+# Core services managed in Docker compose
 NODE_VERSION=18

--- a/ops/env-sample
+++ b/ops/env-sample
@@ -1,0 +1,17 @@
+###########################################################
+# General Setup
+###########################################################
+
+### Compose files  ###############################################################################################
+# The file paths where docker-compose can file its YAML file
+
+COMPOSE_FILE=ops/docker-compose.yml
+
+### prefix for local container ##############################################################################
+COMPOSE_PROJECT_NAME=deployment
+
+### Application
+APPLICATION=..
+
+### Core services managed in Docker compose ##############################################################################
+NODE_VERSION=18

--- a/ops/env-sample
+++ b/ops/env-sample
@@ -3,7 +3,7 @@
 ################################################################################
 
 # Compose files
-COMPOSE_FILE=ops/docker-compose.yml
+COMPOSE_FILE=ops/compose.yaml
 
 # Prefix for local container
 COMPOSE_PROJECT_NAME=gibbondocs
@@ -12,4 +12,4 @@ COMPOSE_PROJECT_NAME=gibbondocs
 APPLICATION=..
 
 # Core services managed in Docker compose
-NODE_VERSION=18
+NODE_VERSION=20

--- a/ops/env-sample
+++ b/ops/env-sample
@@ -8,7 +8,7 @@
 COMPOSE_FILE=ops/docker-compose.yml
 
 ### prefix for local container ##############################################################################
-COMPOSE_PROJECT_NAME=deployment
+COMPOSE_PROJECT_NAME=gibbondocs
 
 ### Application
 APPLICATION=..

--- a/up.sh
+++ b/up.sh
@@ -21,7 +21,7 @@ fi
 echo "Starting local vitepress web server..."
 
 # Install dependencies using npm from Docker container
-docker-compose --env-file .env -f ops/docker-compose.yml run --rm vitepress npm install
+docker-compose run --rm vitepress npm install
 
 # Start Vitepress web server
-docker-compose --env-file .env -f ops/docker-compose.yml up -d
+docker-compose up -d

--- a/up.sh
+++ b/up.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Bails on error
+set -e
+
+# Print command being run
+set -x
+
+# Check there is .env
+if ! [ -f  ./.env ];then
+  cp ops/env-sample .env
+fi
+
+# Check Docker is running
+if ! docker info > /dev/null 2>&1; then
+    echo "❌ Error: Docker is not running"
+    echo "💡 Please start Docker Desktop and try again"
+    exit 1
+fi
+
+echo "Starting local vitepress web server..."
+
+# Install dependencies using npm from Docker container
+docker-compose --env-file .env -f ops/docker-compose.yml run --rm vitepress npm install
+
+# Start Vitepress web server
+docker-compose --env-file .env -f ops/docker-compose.yml up -d

--- a/up.sh
+++ b/up.sh
@@ -21,7 +21,7 @@ fi
 echo "Starting local vitepress web server..."
 
 # Install dependencies using npm from Docker container
-docker-compose run --rm vitepress npm install
+docker compose run --rm vitepress npm install
 
 # Start Vitepress web server
-docker-compose up -d
+docker compose up -d


### PR DESCRIPTION
# Pull request for issue: #90

This is a pull request for the following functionalities:

* A Docker set up for deploying a local vitepress server to view changes to Gibbon documentation

## How to test?

Follow instructions in ops/README.md to deploy the vitepress server on your computer. Once the Docker image has been built and its container run then the Gibbon documentation will be available at http://localhost:5173.

If changes are made to any of the documentation files in your editor then these changes will be seen instantly due to hot reloading being enabled.

## How have functionalities been implemented?

I planned to write instructions for installing node.js and npm, and using the commands to run a local vitepress server. However, instructions to do this will differ according to everyone's development environment.

A Docker setup has been used instead so no manual installation of node.js and npm is required. Also, the source documentation files are not copied into the image, but are bind mounted as a volume in the docker-compose.yml file into the vitepress container. This allows the container to see any changes made to the documentation and then these changes are instantly visible in the browser due to hot reloading.


