### PR TITLE
docs: fix typo in documentation

### DIFF
--- a/guides/administration/gibbon-lifecycle.md
+++ b/guides/administration/gibbon-lifecycle.md
@@ -50,7 +50,7 @@ flowchart LR
 ```
 
 - **School years are divided into terms**
-  These may be called semesters or terms depending on your region, and managed though <u>School Admin > Manage Terms</u>. If you don't use terms, you can set one term that covers the whole year.
+  These may be called semesters or terms depending on your region, and managed through <u>School Admin > Manage Terms</u>. If you don't use terms, you can set one term that covers the whole year.
   
 - **Terms are divided into days**
   The days within each term can be managed through <u>School Admin > Manage Special Days</u>, as well as timetabled with <u>Timetable Admin > Tie Days to Dates</u>.

--- a/guides/install/installing-gibbon.md
+++ b/guides/install/installing-gibbon.md
@@ -67,7 +67,7 @@ If you uploaded to `/var/www/html` then your URL will likely be https://yourdoma
 :::
 ## Installation & Login
 
-The installer will step you though the rest of the installation process, beginning with a system requirements check, and then creating and populating the Gibbon database. 
+The installer will step you through the rest of the installation process, beginning with a system requirements check, and then creating and populating the Gibbon database. 
 
 After completing the installer, you can navigate back to your Gibbon URL to login using the administrator user you created during installation.
 


### PR DESCRIPTION
This pull request makes minor corrections to documentation by fixing typos in two guide files.

- Documentation typo fixes:
  * Corrected "though" to "through" in the description of managing terms in `guides/administration/gibbon-lifecycle.md`.
  * Corrected "step you though" to "step you through" in the installation instructions in `guides/install/installing-gibbon.md`.