### PR TITLE
Improve faqs display

### DIFF
--- a/.vitepress/theme/custom.css
+++ b/.vitepress/theme/custom.css
@@ -8,6 +8,7 @@
 /* FAQ container styling */
 
 /* Hide info icon */
+/* FAQ page specific overrides */
 .faq-page details::before,
 .faq-page details .info::before,
 .faq-page details .info-icon {
@@ -22,6 +23,7 @@
     list-style: none;
     position: relative;
     padding-left: 1.5em;
+    font-size: 18px; /* Increase FAQ question size */
 }
 
 .faq-page summary::-webkit-details-marker,
@@ -57,4 +59,13 @@
     from { opacity: 0; }
     to   { opacity: 1; }
 }
+
+/* FAQ answer text styling */
+.faq-page details p,
+.faq-page details ul,
+.faq-page details li {
+    font-size: 16px; /* Slightly larger answers */
+    line-height: 1.6;
+}
+
 

--- a/.vitepress/theme/custom.css
+++ b/.vitepress/theme/custom.css
@@ -4,3 +4,41 @@
     border-radius: 2px;
     transition: background-color 0.25s;
 }
+
+/* For FAQ accordion display */
+
+/* Target the built-in details container */
+.vp-doc .custom-block.details {
+    /*border: 1px solid var(--vp-c-brand-1); !* Change border color *!*/
+    background-color: var(--vp-c-bg-soft); /* Change background color */
+    border-radius: 8px;
+    padding: 16px;
+    margin: 1.2em 0;
+    transition: background-color 0.3s ease;
+}
+
+.vp-doc .custom-block.details::before {
+    content: none;
+}
+
+/* Style the clickable summary title */
+.vp-doc .custom-block.details summary {
+    font-weight: 600;
+    font-size: 24px;
+    color: var(--vp-c-text-1);
+    cursor: pointer;
+    outline: none;
+    user-select: none;
+}
+
+/* Style the title when hovered */
+.vp-doc .custom-block.details summary:hover {
+    color: var(--vp-c-brand-1);
+}
+
+/* Customize the spacing of the content inside */
+.vp-doc .custom-block.details :not(summary) {
+    margin-top: 0.5rem;
+    font-size: 16px;
+    color: var(--vp-c-text-2);
+}

--- a/.vitepress/theme/custom.css
+++ b/.vitepress/theme/custom.css
@@ -5,40 +5,61 @@
     transition: background-color 0.25s;
 }
 
-/* For FAQ accordion display */
-
-/* Target the built-in details container */
-.vp-doc .custom-block.details {
-    /*border: 1px solid var(--vp-c-brand-1); !* Change border color *!*/
-    background-color: var(--vp-c-bg-soft); /* Change background color */
-    border-radius: 8px;
-    padding: 16px;
-    margin: 1.2em 0;
-    transition: background-color 0.3s ease;
+/* FAQ container styling */
+details {
+    margin: 1em 0;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    padding: 0.5em;
+    background-color: #fafafa;
 }
 
-.vp-doc .custom-block.details::before {
-    content: none;
-}
-
-/* Style the clickable summary title */
-.vp-doc .custom-block.details summary {
-    font-weight: 600;
-    font-size: 24px;
-    color: var(--vp-c-text-1);
+/* Summary (clickable header) */
+summary {
     cursor: pointer;
-    outline: none;
-    user-select: none;
+    font-weight: 600;
+    list-style: none;
 }
 
-/* Style the title when hovered */
-.vp-doc .custom-block.details summary:hover {
-    color: var(--vp-c-brand-1);
+/* Hide Safari’s default marker */
+summary::-webkit-details-marker {
+    display: none;
 }
 
-/* Customize the spacing of the content inside */
-.vp-doc .custom-block.details :not(summary) {
-    margin-top: 0.5rem;
-    font-size: 16px;
-    color: var(--vp-c-text-2);
+/* Expanded state */
+details[open] {
+    background-color: #fff;
+    border-color: #ccc;
 }
+
+/* --- Safari fix ---
+   Prevent ghost line of collapsed content */
+details:not([open]) > :not(summary) {
+    display: none;
+}
+
+/* Expanded content animation */
+details[open] > :not(summary) {
+    animation: fadeIn 0.2s ease-in;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+}
+
+/* FAQ text styling */
+details p {
+    margin: 0.5em 0;
+    line-height: 1.5;
+}
+
+/* Optional: FAQ list styling inside details */
+details ul {
+    margin: 0.5em 0 0.5em 1.5em;
+    padding: 0;
+}
+details li {
+    margin: 0.3em 0;
+}
+

--- a/.vitepress/theme/custom.css
+++ b/.vitepress/theme/custom.css
@@ -6,60 +6,55 @@
 }
 
 /* FAQ container styling */
-details {
-    margin: 1em 0;
-    border: 1px solid #ddd;
-    border-radius: 4px;
-    padding: 0.5em;
-    background-color: #fafafa;
+
+/* Hide info icon */
+.faq-page details::before,
+.faq-page details .info::before,
+.faq-page details .info-icon {
+    content: none !important;
+    display: none !important;
 }
 
-/* Summary (clickable header) */
-summary {
+/* Chevron styling scoped to FAQ page */
+.faq-page summary {
     cursor: pointer;
     font-weight: 600;
     list-style: none;
+    position: relative;
+    padding-left: 1.5em;
 }
 
-/* Hide Safari’s default marker */
-summary::-webkit-details-marker {
+.faq-page summary::-webkit-details-marker,
+.faq-page summary::marker {
     display: none;
 }
 
-/* Expanded state */
-details[open] {
-    background-color: #fff;
-    border-color: #ccc;
+.faq-page summary::before {
+    content: "▶";
+    position: absolute;
+    left: 0;
+    top: 0;
+    font-weight: bold;
+    color: #666;
+    transition: transform 0.2s ease;
 }
 
-/* --- Safari fix ---
-   Prevent ghost line of collapsed content */
-details:not([open]) > :not(summary) {
+.faq-page details[open] > summary::before {
+    transform: rotate(90deg);
+}
+
+/* Safari fix */
+.faq-page details:not([open]) > :not(summary) {
     display: none;
 }
 
 /* Expanded content animation */
-details[open] > :not(summary) {
+.faq-page details[open] > :not(summary) {
     animation: fadeIn 0.2s ease-in;
 }
 
 @keyframes fadeIn {
     from { opacity: 0; }
     to   { opacity: 1; }
-}
-
-/* FAQ text styling */
-details p {
-    margin: 0.5em 0;
-    line-height: 1.5;
-}
-
-/* Optional: FAQ list styling inside details */
-details ul {
-    margin: 0.5em 0 0.5em 1.5em;
-    padding: 0;
-}
-details li {
-    margin: 0.3em 0;
 }
 

--- a/get-started/faq.md
+++ b/get-started/faq.md
@@ -5,55 +5,63 @@ draft: false
 ---
 # Frequently Asked Questions
 
-## How much does Gibbon cost?
+## General
 
-Gibbon is free. As open source software, it is both available "for free" (gratis) and available "with freedom" to modify the code (libre) ([“Gratis versus libre”](https://en.wikipedia.org/wiki/Gratis_versus_libre)). 
+::: details How much does Gibbon cost?
+Gibbon is free. As open source software, it is both available "for free" (gratis) and available "with freedom" to modify the code (libre) ([“Gratis versus libre”](https://en.wikipedia.org/wiki/Gratis_versus_libre)).
 
 To help sustain the Gibbon ecosystem, there are some paid services available for support and development through [GibbonEdu.com](https://gibbonedu.com). However, Gibbon does not use the [freemium](https://en.wikipedia.org/wiki/Freemium) or [SaaS](https://en.wikipedia.org/wiki/Software_as_a_service) model, and all the core features of Gibbon are—**and will always remain**—free.
 
 Web servers, unfortunately, are not free. Schools should be aware that running and maintaining a web server does cost money, so it is recommended to [budget for these costs](/explanation/guide-to-open-source#is-it-really-free).
+:::
 
-## What license does Gibbon use?
-
+::: details What license does Gibbon use?
 Gibbon is a free and open source project released under the [GNU GPL license](https://www.gnu.org/licenses/gpl-3.0.html).
-## Who maintains Gibbon?
+:::
 
-Gibbon is an independent project, maintained by a core development team and supported by a community of volunteer contributors. It was created by Ross Parker in 2010 to meet the needs of International College Hong Kong (ICHK) in Hong Kong. 
+::: details Who maintains Gibbon?
+Gibbon is an independent project, maintained by a core development team and supported by a community of volunteer contributors. It was created by Ross Parker in 2010 to meet the needs of International College Hong Kong (ICHK) in Hong Kong.
 
 Since then, through its open-source roots, Gibbon has grown into a global project. In 2018, Sandra Kuipers stepped into the role of Gibbon's maintainer. Sandra currently leads the development of Gibbon, setting the short-term goals and long-range architecture plans.
 
 In 2023 the [Gibbon Foundation](/get-started/welcome#gibbon-foundation) was established as a non-profit entity incorporated in Hong Kong to further support Gibbon a global project, and the copyright of the Gibbon codebase was transferred from Ross Parker to the Gibbon Foundation.
-## Is Gibbon reliable?
+:::
 
+::: details Is Gibbon reliable?
 One of the core development principles of Gibbon is to maintain stable, reliable software. After all, the school where Gibbon was developed {{ new Date().getFullYear() - 2010 }} years ago still uses it daily for all aspects of school management. While some software companies "[move fast and break things](https://en.wikipedia.org/wiki/Move_fast_and_break_things)," the Gibbon project "moves deliberately and sustains things." Schools need software that can be relied upon from day-to-day, and this philosophy is at the heart of our [developer workflow](development/getting-started/developer-workflow.md) and [release cycle](/explanation/development/gibbon-road-map.md).
+:::
 
-## How many schools use Gibbon?
-
+::: details How many schools use Gibbon?
 As of 2024, there have been more than 18,000 installations of Gibbon, with thousands of schools using Gibbon world-wide. We cannot know the exact number of schools using it, since the software is freely available to download, but we have a strong indication from the opt-in installer statistics and the activity on community forums.
+:::
 
-## How can I translate Gibbon into my language?
-
+::: details How can I translate Gibbon into my language?
 Thanks to our amazing volunteers, Gibbon is available in 21 different languages, with many more in translation. If you would like to help translate Gibbon, please email [support@gibbonedu.org](mailto:support@gibbonedu.org). Your help would be most appreciated!
 
 Gibbon uses the POEditor online translation platform to manage and collect translations from community volunteers. When you join the translation team, we'll send you an invite to create an account. Newly translated terms are published with [each Gibbon release](/explanation/development/gibbon-road-map.md).
+:::
 
-## How do I add a new feature to Gibbon?
+::: details Can I use Gibbon for higher education?
+Gibbon was designed for K to 12 schools, so there are certain assumptions that the system makes about admissions and enrolment (eg: that the student is attached to a family). However, this does not prevent using Gibbon for different needs. But, it's important to keep in mind that the needs and demands of a university will be very different than a K-12 school, especially depending on the size of the school. For this reason, if you're looking at Gibbon for alternate purposes, we encourage you to [download and install](/guides/install/installing-gibbon) the software locally to test its functionalities to see if they suit your needs.
+:::
 
+::: details Can I use Gibbon for training centres or other schools?
+Like its namesake animal, Gibbon has been designed to be highly flexible. So, while it was designed with traditional schools in mind, we have seen community members use it successfully for homes schooling, music schools, language schools, and private tutoring centres. Through the [Free Learning](https://gibbonedu.org/extend/#free-learning) module, Gibbon has also been used as a [professional development platform](https://gorillapd.org/). It all depends on the needs of the school and how these map to the available features in Gibbon. Be sure to download it and test it out, and [search on the forums](https://ask.gibbonedu.org) to see how other schools have adapted Gibbon.
+:::
+
+## Technical
+
+::: details How do I add a new feature to Gibbon?
 Upcoming features can be found on our [road map](/explanation/development/gibbon-road-map), and you are welcome to [request new features](https://ask.gibbonedu.org/c/feature-requests/12) on our forums. However, please note that development capacity is generally focused towards features that are sustainable and provide the greatest value to the widest range of schools. Our small development team also focuses much of our capacity on refactoring and maintaining the codebase.
 
 Schools who have or hire a developer can [create their own modules](/explanation/development/module-development) to meet their needs. This is the most flexible and sustainable way to add new functionality. Developers are also welcome to [program new features](development/getting-started/developer-workflow.md) for the core, but are recommended to get in touch with our team to ensure their changes fit within the scope and direction of the core.
+:::
 
-## Does Gibbon have an API?
-
+::: details Does Gibbon have an API?
 As of 2024, Gibbon does not currently have a general-purpose API. The reasons for this are many and varied, partially due to ongoing refactoring efforts, and the limited capacity of the core development team. We do have plans to implement an API in the future, but aim to only do so once certain infrastructure is in place to ensure that the API security layer is rock-solid, since any API in Gibbon would entail access to private school data.
+:::
 
-## Does Gibbon support multi-installs or school districts?
+::: details Does Gibbon support multi-installs or school districts?
 
 A multi-tenant option is one of the future goals of Gibbon, to enable installing and managing multiple schools on a single server. However, to make this work, there are currently a number of architectural changes and refactoring initiatives that need to be completed first. For this reason, a multi-install or school-district version of Gibbon remains on the [long-term road map](/explanation/development/gibbon-road-map).
-## Can I use Gibbon for higher education?
-
-Gibbon was designed for K to 12 schools, so there are certain assumptions that the system makes about admissions and enrolment (eg: that the student is attached to a family). However, this does not prevent using Gibbon for different needs. But, it's important to keep in mind that the needs and demands of a university will be very different than a K-12 school, especially depending on the size of the school. For this reason, if you're looking at Gibbon for alternate purposes, we encourage you to [download and install](/guides/install/installing-gibbon) the software locally to test its functionalities to see if they suit your needs.
-
-## Can I use Gibbon for training centres or other schools?
-
-Like its namesake animal, Gibbon has been designed to be highly flexible. So, while it was designed with traditional schools in mind, we have seen community members use it successfully for homes schooling, music schools, language schools, and private tutoring centres. Through the [Free Learning](https://gibbonedu.org/extend/#free-learning) module, Gibbon has also been used as a [professional development platform](https://gorillapd.org/). It all depends on the needs of the school and how these map to the available features in Gibbon. Be sure to download it and test it out, and [search on the forums](https://ask.gibbonedu.org) to see how other schools have adapted Gibbon.
+:::

--- a/get-started/faq.md
+++ b/get-started/faq.md
@@ -5,6 +5,8 @@ draft: false
 ---
 # Frequently Asked Questions
 
+<div class="faq-page">
+
 ## General
 
 ::: details How much does Gibbon cost?
@@ -65,3 +67,5 @@ As of 2024, Gibbon does not currently have a general-purpose API. The reasons fo
 
 A multi-tenant option is one of the future goals of Gibbon, to enable installing and managing multiple schools on a single server. However, to make this work, there are currently a number of architectural changes and refactoring initiatives that need to be completed first. For this reason, a multi-install or school-district version of Gibbon remains on the [long-term road map](/explanation/development/gibbon-road-map).
 :::
+
+</div>


### PR DESCRIPTION
# Pull request for issue: #107 Improve FAQs page

This is a pull request for the following functionalities:

* An updated FAQs page showing a list of FAQs.

The answer is displayed on clicking on a FAQ. Users can now quickly browse all of the FAQs to find a specific answer they might be looking for. Previously, a user would have to scroll through all questions and answers to browse the FAQs. Also, FAQs have been separated into General and Technical FAQs as a start on grouping FAQs into sections.

## How to test?

1. Execute ./up.sh and go to http://localhost:5173/get-started/faq in your browser
2. Click on any FAQ. It will expand to show the answer for the clicked FAQ.

## How have functionalities been implemented?

The accordion-like display for each FAQ has been implemented by using the details custom container - see https://vitepress.dev/guide/markdown.

There is new styling in `custom.css` to customise the look of the details custom container for FAQs.


